### PR TITLE
Get dependencies from builder instead of base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN yarn install --production
 
 # ---------- Release ----------
 FROM base as release
-COPY ./dependencies ./dependencies
 COPY ./src ./src
+COPY --from=builder /app/dependencies ./dependencies
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./src
 ENV PATH "$PATH:/app/dependencies/belenios/_build/install/default/bin"


### PR DESCRIPTION
Avant les dependencies étais ajouter de la 'base' se qui fesait en sorte que quand on déployais sans avoir unzip belenios ca plantait. Maintenant on peu deploy après avoir cloné le projet et ajuster les settings sans problème.